### PR TITLE
Move constants to context-managed GridfinityConfig

### DIFF
--- a/cqgridfinity/__init__.py
+++ b/cqgridfinity/__init__.py
@@ -2,6 +2,13 @@
 
 import os
 
+from .constants import GridfinityConfig
+from .gf_obj import GridfinityObject
+from .gf_baseplate import GridfinityBaseplate
+from .gf_box import GridfinityBox, GridfinitySolidBox
+from .gf_drawer import GridfinityDrawerSpacer
+from .gf_ruggedbox import GridfinityRuggedBox
+
 # fmt: off
 __project__ = 'cqgridfinity'
 __version__ = '0.5.7'
@@ -11,9 +18,4 @@ VERSION = __project__ + "-" + __version__
 
 script_dir = os.path.dirname(__file__)
 
-from .constants import *
-from .gf_obj import GridfinityObject
-from .gf_baseplate import GridfinityBaseplate
-from .gf_box import GridfinityBox, GridfinitySolidBox
-from .gf_drawer import GridfinityDrawerSpacer
-from .gf_ruggedbox import GridfinityRuggedBox
+__all__ = ["GridfinityConfig", "GridfinityObject", "GridfinityBaseplate", "GridfinityBox", "GridfinitySolidBox", "GridfinityDrawerSpacer", "GridfinityRuggedBox"]

--- a/cqgridfinity/constants.py
+++ b/cqgridfinity/constants.py
@@ -23,152 +23,218 @@
 #
 # Globally useful constants representing Gridfinity geometry
 
+from dataclasses import dataclass
+import contextlib
 from math import sqrt
 
 SQRT2 = sqrt(2)
-EPS = 1e-5
-M2_DIAM = 1.8
-M2_CLR_DIAM = 2.5
-M3_DIAM = 3
-M3_CLR_DIAM = 3.5
-M3_CB_DIAM = 5.5
-M3_CB_DEPTH = 3.5
 
-GRU = 42
-GRU2 = GRU / 2
-GRHU = 7
 
-GRU_CUT = 42.2  # base extrusion width
-GR_WALL = 1.0  # nominal exterior wall thickness
-GR_DIV_WALL = 1.2  # width of dividing walls
-GR_TOL = 0.5  # nominal tolerance
+@dataclass
+class GridfinityConfig(contextlib.ContextDecorator):
+    GRU: float = 42
+    GRHU: float = 7
+    
+    @property
+    def GRU2(self):
+        return self.GRU / 2
+    
+    @property
+    def GRU_CUT(self):
+        return self.GRU + 0.2
+    
+    GR_WALL: float = 1.0  # nominal exterior wall thickness
+    GR_DIV_WALL: float = 1.2  # width of dividing walls
+    GR_TOL: float = 0.5  # nominal tolerance
 
-GR_RAD = 4  # nominal exterior filleting radius
-GR_BASE_CLR = 0.25  # clearance above the nominal base height
-GR_BASE_HEIGHT = 4.75  # nominal base height
+    GR_RAD: float = 4  # nominal exterior filleting radius
+    GR_BASE_CLR: float = 0.25  # clearance above the nominal base height
+    GR_BASE_HEIGHT: float = 4.75  # nominal base height
 
-# baseplate extrusion profile
-GR_BASE_CHAMF_H = 0.98994949 / SQRT2
-GR_STR_H = 1.8
-GR_BASE_TOP_CHAMF = GR_BASE_HEIGHT - GR_BASE_CHAMF_H - GR_STR_H
-GR_BASE_PROFILE = (
-    (GR_BASE_TOP_CHAMF * SQRT2, 45),
-    GR_STR_H,
-    (GR_BASE_CHAMF_H * SQRT2, 45),
-)
-GR_STR_BASE_PROFILE = (
-    (GR_BASE_TOP_CHAMF * SQRT2, 45),
-    GR_STR_H + GR_BASE_CHAMF_H,
-)
+    # baseplate extrusion profile
+    GR_BASE_CHAMF_H: float = 0.98994949 / SQRT2
+    GR_STR_H: float = 1.8
+    
+    EPS = 1e-5
+    M2_DIAM = 1.8
+    M2_CLR_DIAM = 2.5
+    M3_DIAM = 3
+    M3_CLR_DIAM = 3.5
+    M3_CB_DIAM = 5.5
+    M3_CB_DEPTH = 3.5
+    
+    @property
+    def GR_BASE_TOP_CHAMF(self):
+        return self.GR_BASE_HEIGHT - self.GR_BASE_CHAMF_H - self.GR_STR_H
+    
+    @property
+    def GR_BASE_PROFILE(self):
+        return (
+            (self.GR_BASE_TOP_CHAMF * SQRT2, 45),
+            self.GR_STR_H,
+            (self.GR_BASE_CHAMF_H * SQRT2, 45),
+        )
+    
+    @property
+    def GR_STR_BASE_PROFILE(self):
+        return (
+            (self.GR_BASE_TOP_CHAMF * SQRT2, 45),
+            self.GR_STR_H + self.GR_BASE_CHAMF_H,
+        )
 
-GR_BOT_H = 7  # bin nominal floor height
-GR_FILLET = 1.1  # inside filleting radius
-GR_FLOOR = GR_BOT_H - GR_BASE_HEIGHT  # floor offset
+    GR_BOT_H: float = 7  # bin nominal floor height
+    GR_FILLET: float = 1.1  # inside filleting radius
 
-# box/bin extrusion profile
-GR_BOX_CHAMF_H = 1.1313708 / SQRT2
-GR_BOX_TOP_CHAMF = GR_BASE_HEIGHT - GR_BOX_CHAMF_H - GR_STR_H + GR_BASE_CLR
-GR_BOX_PROFILE = (
-    (GR_BOX_TOP_CHAMF * SQRT2, 45),
-    GR_STR_H,
-    (GR_BOX_CHAMF_H * SQRT2, 45),
-)
+    @property
+    def GR_FLOOR(self):
+        return self.GR_BOT_H - self.GR_BASE_HEIGHT  # floor offset
 
-# bin mating lip extrusion profile
-GR_UNDER_H = 1.6
-GR_TOPSIDE_H = 1.2
-GR_LIP_PROFILE = (
-    (GR_UNDER_H * SQRT2, 45),
-    GR_TOPSIDE_H,
-    (0.7 * SQRT2, -45),
-    1.8,
-    (1.3 * SQRT2, -45),
-)
-GR_LIP_H = 0
-for h in GR_LIP_PROFILE:
-    if isinstance(h, tuple):
-        GR_LIP_H += h[0] / SQRT2
-    else:
-        GR_LIP_H += h
-GR_NO_PROFILE = (GR_LIP_H,)
+    # box/bin extrusion profile
+    GR_BOX_CHAMF_H: float = 1.1313708 / SQRT2
 
-# bottom hole nominal dimensions
-GR_HOLE_D = 6.5
-GR_HOLE_H = 2.4
-GR_BOLT_D = 3.0
-GR_BOLT_H = 3.6 + GR_HOLE_H
-GR_HOLE_DIST = 26 / 2
-GR_HOLE_SLICE = 0.25
+    @property
+    def GR_BOX_TOP_CHAMF(self):
+        return self.GR_BASE_HEIGHT - self.GR_BOX_CHAMF_H - self.GR_STR_H + self.GR_BASE_CLR
+    
+    @property
+    def GR_BOX_PROFILE(self):
+        return (
+            (self.GR_BOX_TOP_CHAMF * SQRT2, 45),
+            self.GR_STR_H,
+            (self.GR_BOX_CHAMF_H * SQRT2, 45),
+        )
 
-# Rugged Box constant parameters
-GR_RBOX_WALL = 2.5
-GR_RBOX_FLOOR = 1.2
-GR_RBOX_CWALL = 10.0
-GR_RBOX_CORNER_W = 56
-GR_RBOX_BACK_L = 66
-GR_RBOX_FRONT_L = 56
-GR_RBOX_RAD = 3.745
-GR_RBOX_CRAD = 14
+    def __enter__(self):
+        global _c
+        self._prev_config = _c
+        _c = self
+        return self
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        global _c
+        _c = self._prev_config
+        return False
 
-GR_RBOX_CHAN_W = 20
-GR_RBOX_CHAN_D = GR_RBOX_CWALL - GR_RBOX_WALL
-GR_RBOX_VCUT_D = 1
+    def make_default(self):
+        global _c
+        _c = self
 
-GR_CLASP_SLIDE_D = 39
-GR_CLASP_SLIDE_W = 4
+    # bin mating lip extrusion profile
+    GR_UNDER_H = 1.6
+    GR_TOPSIDE_H = 1.2
 
-GR_RIB_W = 2
-GR_RIB_L = 5
-GR_RIB_GAP = 1
-GR_RIB_H = 3.5
-GR_RIB_SEP = 4
-GR_RIB_CTR = 10
+    @property
+    def GR_LIP_PROFILE(self):
+        return (
+            (self.GR_UNDER_H * SQRT2, 45),
+            self.GR_TOPSIDE_H,
+            (0.7 * SQRT2, -45),
+            1.8,
+            (1.3 * SQRT2, -45),
+            )
 
-GR_REG_L = 5
-GR_REG_W = 2.5
-GR_REG_H = 2.5
-GR_REG_R0 = 10.75
-GR_REG_R1 = 8.25
-GR_BREG_R0 = GR_REG_R0 + 0.25
-GR_BREG_R1 = GR_REG_R1 - 0.25
+    @property
+    def GR_LIP_H(self):
+        GR_LIP_H = 0
+        for h in self.GR_LIP_PROFILE:
+            if isinstance(h, tuple):
+                GR_LIP_H += h[0] / SQRT2
+            else:
+                GR_LIP_H += h
+        return GR_LIP_H
 
-GR_HANDLE_L1 = 12
-GR_HANDLE_L2 = 28
-GR_HANDLE_H = 7.5
-GR_HANDLE_W = 5
-GR_HANDLE_SEP = 12.5
-GR_HANDLE_OFS = 61.5
-GR_HANDLE_SZ = 30
-GR_HANDLE_TH = 7
-GR_HANDLE_RAD = 11
+    @property
+    def GR_NO_PROFILE(self):
+        return (self.GR_LIP_H,)
 
-GR_LID_HANDLE_W = 70
-GR_SIDE_HANDLE_W = 60
+    # bottom hole nominal dimensions
+    GR_HOLE_D = 6.5
+    GR_HOLE_H = 2.4
+    GR_BOLT_D = 3.0
+    @property
+    def GR_BOLT_H(self):
+        return 3.6 + self.GR_HOLE_H
+    GR_HOLE_DIST = 26 / 2
+    GR_HOLE_SLICE = 0.25
 
-GR_HINGE_SZ = 32
-GR_HINGE_D = 3
-GR_HINGE_W1 = 5.5
-GR_HINGE_H1 = 2.7
-GR_HINGE_W2 = 2.1
-GR_HINGE_H2 = 9
-GR_HINGE_CTR = 30.625
-GR_HINGE_W3 = 2
-GR_HINGE_SEP = 1
-GR_HINGE_OFFS = 2.65
-GR_HINGE_SKEW = 0.15
-GR_HINGE_RAD = 3.5
-GR_HINGE_TOL = 0.4
-GR_HEX_H = 3
-GR_HEX_W = 4
-GR_HEX_D = 1.3
-GR_LID_WINDOW_H = 6.5
+    # Rugged Box constant parameters
+    GR_RBOX_WALL = 2.5
+    GR_RBOX_FLOOR = 1.2
+    GR_RBOX_CWALL = 10.0
+    GR_RBOX_CORNER_W = 56
+    GR_RBOX_BACK_L = 66
+    GR_RBOX_FRONT_L = 56
+    GR_RBOX_RAD = 3.745
+    GR_RBOX_CRAD = 14
 
-GR_LABEL_SLOT_TH = 2.5
-GR_LABEL_TH = 0.8
-GR_LABEL_H = 31
+    GR_RBOX_CHAN_W = 20
 
-GR_LATCH_L = 32.5
-GR_LATCH_W = 19.6
-GR_LATCH_H = 7
-GR_LATCH_IW = 14.75
-GR_LATCH_IL = 5.2
+    @property
+    def GR_RBOX_CHAN_D(self):
+        return self.GR_RBOX_CWALL - self.GR_RBOX_WALL
+    GR_RBOX_VCUT_D = 1
+
+    GR_CLASP_SLIDE_D = 39
+    GR_CLASP_SLIDE_W = 4
+
+    GR_RIB_W = 2
+    GR_RIB_L = 5
+    GR_RIB_GAP = 1
+    GR_RIB_H = 3.5
+    GR_RIB_SEP = 4
+    GR_RIB_CTR = 10
+
+    GR_REG_L = 5
+    GR_REG_W = 2.5
+    GR_REG_H = 2.5
+    GR_REG_R0 = 10.75
+    GR_REG_R1 = 8.25
+    @property
+    def GR_BREG_R0(self):
+        return self.GR_REG_R0 + 0.25
+    @property
+    def GR_BREG_R1(self):
+        return self.GR_REG_R1 - 0.25
+
+    GR_HANDLE_L1 = 12
+    GR_HANDLE_L2 = 28
+    GR_HANDLE_H = 7.5
+    GR_HANDLE_W = 5
+    GR_HANDLE_SEP = 12.5
+    GR_HANDLE_OFS = 61.5
+    GR_HANDLE_SZ = 30
+    GR_HANDLE_TH = 7
+    GR_HANDLE_RAD = 11
+
+    GR_LID_HANDLE_W = 70
+    GR_SIDE_HANDLE_W = 60
+
+    GR_HINGE_SZ = 32
+    GR_HINGE_D = 3
+    GR_HINGE_W1 = 5.5
+    GR_HINGE_H1 = 2.7
+    GR_HINGE_W2 = 2.1
+    GR_HINGE_H2 = 9
+    GR_HINGE_CTR = 30.625
+    GR_HINGE_W3 = 2
+    GR_HINGE_SEP = 1
+    GR_HINGE_OFFS = 2.65
+    GR_HINGE_SKEW = 0.15
+    GR_HINGE_RAD = 3.5
+    GR_HINGE_TOL = 0.4
+    GR_HEX_H = 3
+    GR_HEX_W = 4
+    GR_HEX_D = 1.3
+    GR_LID_WINDOW_H = 6.5
+
+    GR_LABEL_SLOT_TH = 2.5
+    GR_LABEL_TH = 0.8
+    GR_LABEL_H = 31
+
+    GR_LATCH_L = 32.5
+    GR_LATCH_W = 19.6
+    GR_LATCH_H = 7
+    GR_LATCH_IW = 14.75
+    GR_LATCH_IL = 5.2
+
+_c = GridfinityConfig()

--- a/cqgridfinity/gf_baseplate.py
+++ b/cqgridfinity/gf_baseplate.py
@@ -79,20 +79,20 @@ class GridfinityBaseplate(GridfinityObject):
         ]
 
     def render(self):
-        profile = GR_BASE_PROFILE if not self.straight_bottom else GR_STR_BASE_PROFILE
+        profile = self.c.GR_BASE_PROFILE if not self.straight_bottom else self.c.GR_STR_BASE_PROFILE
         if self.ext_depth > 0:
             profile = [*profile, self.ext_depth]
         rc = self.extrude_profile(
-            rounded_rect_sketch(GRU_CUT, GRU_CUT, GR_RAD), profile
+            rounded_rect_sketch(self.c.GRU_CUT, self.c.GRU_CUT, self.c.GR_RAD), profile
         )
-        rc = rotate_x(rc, 180).translate((GRU2, GRU2, GR_BASE_HEIGHT + self.ext_depth))
+        rc = rotate_x(rc, 180).translate((self.c.GRU2, self.c.GRU2, self.c.GR_BASE_HEIGHT + self.ext_depth))
         rc = recentre(composite_from_pts(rc, self.grid_centres), "XY")
         r = (
             cq.Workplane("XY")
             .rect(self.length, self.width)
-            .extrude(GR_BASE_HEIGHT + self.ext_depth)
+            .extrude(self.c.GR_BASE_HEIGHT + self.ext_depth)
             .edges("|Z")
-            .fillet(GR_RAD)
+            .fillet(self.c.GR_RAD)
             .faces(">Z")
             .cut(rc)
         )
@@ -104,5 +104,5 @@ class GridfinityBaseplate(GridfinityObject):
             )
             r = r.union(recentre(composite_from_pts(rs, self._corner_pts()), "XY"))
             bs = VerticalEdgeSelector(self.ext_depth) & HasZCoordinateSelector(0)
-            r = r.edges(bs).fillet(GR_RAD)
+            r = r.edges(bs).fillet(self.c.GR_RAD)
         return r

--- a/cqgridfinity/gf_box.py
+++ b/cqgridfinity/gf_box.py
@@ -29,6 +29,7 @@ import cadquery as cq
 from cqkit import HasZCoordinateSelector, VerticalEdgeSelector, FlatEdgeSelector
 from cqkit.cq_helpers import rounded_rect_sketch, composite_from_pts
 from cqgridfinity import *
+from cqgridfinity.constants import SQRT2
 
 
 class GridfinityBox(GridfinityObject):
@@ -85,8 +86,8 @@ class GridfinityBox(GridfinityObject):
         self.label_lip_height = 0.8  # thickness of label vertical lip
         self.scoop_rad = 14  # radius of optional interior scoops
         self.fillet_interior = True
-        self.wall_th = GR_WALL
-        self.hole_diam = GR_HOLE_D  # magnet/bolt hole diameter
+        self.wall_th = self.c.GR_WALL
+        self.hole_diam = self.c.GR_HOLE_D  # magnet/bolt hole diameter
         for k, v in kwargs.items():
             if k in self.__dict__:
                 self.__dict__[k] = v
@@ -101,8 +102,8 @@ class GridfinityBox(GridfinityObject):
                 self.length_u,
                 self.width_u,
                 self.height_u,
-                self.length - GR_TOL,
-                self.width - GR_TOL,
+                self.length - self.c.GR_TOL,
+                self.width - self.c.GR_TOL,
                 self.height,
             )
         )
@@ -111,7 +112,7 @@ class GridfinityBox(GridfinityObject):
         s.append("  %sWall thickness: %.2f mm  %s" % (ss, self.wall_th, sl))
         s.append(
             "  Floor height  : %.2f mm  Inside height: %.2f mm  Top reference height: %.2f mm"
-            % (self.floor_h + GR_BASE_HEIGHT, self.int_height, self.top_ref_height)
+            % (self.floor_h + self.c.GR_BASE_HEIGHT, self.int_height, self.top_ref_height)
         )
         if self.solid:
             s.append("  Solid filled box with fill ratio %.2f" % (self.solid_ratio))
@@ -127,7 +128,7 @@ class GridfinityBox(GridfinityObject):
                 % (self.label_width, self.label_height)
             )
         if self.length_div:
-            xl = (self.inner_l - GR_DIV_WALL * (self.length_div)) / (
+            xl = (self.inner_l - self.c.GR_DIV_WALL * (self.length_div)) / (
                 self.length_div + 1
             )
             s.append(
@@ -135,7 +136,7 @@ class GridfinityBox(GridfinityObject):
                 % (self.length_div, xl)
             )
         if self.width_div:
-            yl = (self.inner_w - GR_DIV_WALL * (self.width_div)) / (self.width_div + 1)
+            yl = (self.inner_w - self.c.GR_DIV_WALL * (self.width_div)) / (self.width_div + 1)
             s.append(
                 "  %dx widthwise divisions for %.2f mm compartment widths"
                 % (self.width_div, yl)
@@ -177,7 +178,7 @@ class GridfinityBox(GridfinityObject):
             if e is not None:
                 r = r.union(e)
         if not self.solid and self.fillet_interior:
-            heights = [GR_FLOOR]
+            heights = [self.c.GR_FLOOR]
             if self.labels:
                 heights.append(self.safe_label_height(backwall=True, from_bottom=True))
                 heights.append(self.safe_label_height(backwall=False, from_bottom=True))
@@ -200,13 +201,13 @@ class GridfinityBox(GridfinityObject):
 
             if not self.labels and self.has_dividers:
                 bs = VerticalEdgeSelector(
-                    GR_TOPSIDE_H, tolerance=0.05
-                ) & HasZCoordinateSelector(GRHU * self.height_u - GR_BASE_HEIGHT)
-                r = self.safe_fillet(r, bs, GR_TOPSIDE_H - EPS)
+                    self.c.GR_TOPSIDE_H, tolerance=0.05
+                ) & HasZCoordinateSelector(self.c.GRHU * self.height_u - self.c.GR_BASE_HEIGHT)
+                r = self.safe_fillet(r, bs, self.c.GR_TOPSIDE_H - self.c.EPS)
 
         if self.holes:
             r = self.render_holes(r)
-        r = r.translate((-self.half_l, -self.half_w, GR_BASE_HEIGHT))
+        r = r.translate((-self.half_l, -self.half_w, self.c.GR_BASE_HEIGHT))
         if self.unsupported_holes:
             r = self.render_hole_fillers(r)
         return r
@@ -216,14 +217,14 @@ class GridfinityBox(GridfinityObject):
         """The height of the top surface of a solid box or the floor
         height of an empty box."""
         if self.solid:
-            return self.max_height * self.solid_ratio + GR_BOT_H
+            return self.max_height * self.solid_ratio + self.c.GR_BOT_H
         if self.lite_style:
             return self.floor_h
-        return GR_BOT_H
+        return self.c.GR_BOT_H
 
     @property
     def bin_height(self):
-        return self.height - GR_BASE_HEIGHT
+        return self.height - self.c.GR_BASE_HEIGHT
 
     def safe_label_height(self, backwall=False, from_bottom=False):
         lw = self.label_width
@@ -234,15 +235,15 @@ class GridfinityBox(GridfinityObject):
         if backwall:
             yl -= self.lip_width
         if yl < 0:
-            lh = self.max_height - 1.5 * GR_FILLET - 0.1
-        elif yl < 1.5 * GR_FILLET:
-            lh -= 1.5 * GR_FILLET - yl + 0.1
+            lh = self.max_height - 1.5 * self.c.GR_FILLET - 0.1
+        elif yl < 1.5 * self.c.GR_FILLET:
+            lh -= 1.5 * self.c.GR_FILLET - yl + 0.1
         if from_bottom:
             ws = math.sin(math.atan2(self.label_height, self.label_width))
             if backwall:
-                lh = self.max_height + GR_FLOOR - lh + ws * self.wall_th
+                lh = self.max_height + self.c.GR_FLOOR - lh + ws * self.wall_th
             else:
-                lh = self.max_height + GR_FLOOR - lh + ws * GR_DIV_WALL
+                lh = self.max_height + self.c.GR_FLOOR - lh + ws * self.c.GR_DIV_WALL
         return lh
 
     @property
@@ -258,13 +259,13 @@ class GridfinityBox(GridfinityObject):
 
     def render_interior(self, force_solid=False):
         """Renders the interior cutting solid of the box."""
-        wall_u = self.wall_th - GR_WALL
+        wall_u = self.wall_th - self.c.GR_WALL
         wall_h = self.int_height + wall_u
-        under_h = ((GR_UNDER_H - wall_u) * SQRT2, 45)
-        profile = GR_NO_PROFILE if self.no_lip else [under_h, *GR_LIP_PROFILE[1:]]
+        under_h = ((self.c.GR_UNDER_H - wall_u) * SQRT2, 45)
+        profile = self.c.GR_NO_PROFILE if self.no_lip else [under_h, *self.c.GR_LIP_PROFILE[1:]]
         profile = [wall_h, *profile]
         if self.int_height < 0:
-            profile = [self.height - GR_BOT_H]
+            profile = [self.height - self.c.GR_BOT_H]
         rci = self.extrude_profile(
             rounded_rect_sketch(*self.inner_dim, self.inner_rad), profile
         )
@@ -301,14 +302,14 @@ class GridfinityBox(GridfinityObject):
         return obj.intersect(self.solid_shell())
 
     def base_interior(self):
-        profile = [GR_BASE_HEIGHT, *GR_BOX_PROFILE]
-        zo = GR_BASE_HEIGHT + GR_BASE_CLR
+        profile = [self.c.GR_BASE_HEIGHT, *self.c.GR_BOX_PROFILE]
+        zo = self.c.GR_BASE_HEIGHT + self.c.GR_BASE_CLR
         if self.int_height < 0:
-            h = self.bin_height - GR_BASE_HEIGHT
+            h = self.bin_height - self.c.GR_BASE_HEIGHT
             profile = [h, *profile]
             zo += h
         r = self.extrude_profile(
-            rounded_rect_sketch(GRU - GR_TOL, GRU - GR_TOL, self.outer_rad),
+            rounded_rect_sketch(self.c.GRU - self.c.GR_TOL, self.c.GRU - self.c.GR_TOL, self.outer_rad),
             profile,
         )
         rx = r.faces("<Z").shell(-self.wall_th)
@@ -318,22 +319,22 @@ class GridfinityBox(GridfinityObject):
     def render_shell(self, as_solid=False):
         """Renders the box shell without any added features."""
         r = self.extrude_profile(
-            rounded_rect_sketch(GRU, GRU, self.outer_rad + GR_BASE_CLR), GR_BOX_PROFILE
+            rounded_rect_sketch(self.c.GRU, self.c.GRU, self.outer_rad + self.c.GR_BASE_CLR), self.c.GR_BOX_PROFILE
         )
-        r = r.translate((0, 0, -GR_BASE_CLR))
+        r = r.translate((0, 0, -self.c.GR_BASE_CLR))
         r = r.mirror(mirrorPlane="XY")
         r = composite_from_pts(r, self.grid_centres)
         rs = rounded_rect_sketch(*self.outer_dim, self.outer_rad)
         rw = (
             cq.Workplane("XY")
             .placeSketch(rs)
-            .extrude(self.bin_height - GR_BASE_CLR)
-            .translate((*self.half_dim, GR_BASE_CLR))
+            .extrude(self.bin_height - self.c.GR_BASE_CLR)
+            .translate((*self.half_dim, self.c.GR_BASE_CLR))
         )
         rc = (
             cq.Workplane("XY")
             .placeSketch(rs)
-            .extrude(-GR_BASE_HEIGHT - 1)
+            .extrude(-self.c.GR_BASE_HEIGHT - 1)
             .translate((*self.half_dim, 0.5))
         )
         rc = rc.intersect(r).union(rw)
@@ -346,7 +347,7 @@ class GridfinityBox(GridfinityObject):
         if self.length_div > 0 and not self.solid:
             wall_w = (
                 cq.Workplane("XY")
-                .rect(GR_DIV_WALL, self.outer_w)
+                .rect(self.c.GR_DIV_WALL, self.outer_w)
                 .extrude(self.max_height)
                 .translate((0, 0, self.floor_h))
             )
@@ -360,7 +361,7 @@ class GridfinityBox(GridfinityObject):
         if self.width_div > 0 and not self.solid:
             wall_l = (
                 cq.Workplane("XY")
-                .rect(self.outer_l, GR_DIV_WALL)
+                .rect(self.outer_l, self.c.GR_DIV_WALL)
                 .extrude(self.max_height)
                 .translate((0, 0, self.floor_h))
             )
@@ -384,12 +385,12 @@ class GridfinityBox(GridfinityObject):
         srad = min(self.scoop_rad, self.int_height - 0.1)
         rs = cq.Sketch().rect(srad, srad).vertices(">X and >Y").circle(srad, mode="s")
         rsc = cq.Workplane("YZ").placeSketch(rs).extrude(self.inner_l)
-        rsc = rsc.translate((0, 0, srad / 2 + GR_FLOOR))
+        rsc = rsc.translate((0, 0, srad / 2 + self.c.GR_FLOOR))
         yo = -self.half_in + srad / 2
         # offset front wall scoop by top lip overhang if applicable
         if not self.no_lip and not self.lite_style:
             yo += self.under_h
-        zo = -GR_BOT_H + self.wall_th if self.lite_style else 0
+        zo = -self.c.GR_BOT_H + self.wall_th if self.lite_style else 0
         rs = rsc.translate((-self.half_in, yo, zo))
         # intersect to prevent solids sticking out of rounded corners
         r = rs.intersect(self.interior_solid)
@@ -401,7 +402,7 @@ class GridfinityBox(GridfinityObject):
                 for y in range(self.width_div)
             ]
             rs = composite_from_pts(rsc, pts)
-            r = r.union(rs.translate((0, GR_DIV_WALL / 2 + srad / 2, zo)))
+            r = r.union(rs.translate((0, self.c.GR_DIV_WALL / 2 + srad / 2, zo)))
             r = r.intersect(self.render_shell(as_solid=True))
         return r
 
@@ -443,7 +444,7 @@ class GridfinityBox(GridfinityObject):
             rsc = rsc.translate((0, -self.label_width, self.floor_h + self.max_height))
             yl = self.inner_w / (self.width_div + 1)
             pts = [
-                (-self.half_in, (y + 1) * yl - self.half_in + GR_DIV_WALL / 2)
+                (-self.half_in, (y + 1) * yl - self.half_in + self.c.GR_DIV_WALL / 2)
                 for y in range(self.width_div)
             ]
             r = r.union(composite_from_pts(rsc, pts))
@@ -452,24 +453,24 @@ class GridfinityBox(GridfinityObject):
     def render_holes(self, obj):
         if not self.holes:
             return obj
-        h = GR_HOLE_H
+        h = self.c.GR_HOLE_H
         if self.unsupported_holes:
-            h += GR_HOLE_SLICE
+            h += self.c.GR_HOLE_SLICE
         return (
             obj.faces("<Z")
             .workplane()
             .pushPoints(self.hole_centres)
-            .cboreHole(GR_BOLT_D, self.hole_diam, h, depth=GR_BOLT_H)
+            .cboreHole(self.c.GR_BOLT_D, self.hole_diam, h, depth=self.c.GR_BOLT_H)
         )
 
     def render_hole_fillers(self, obj):
         rc = (
             cq.Workplane("XY")
             .rect(self.hole_diam / 2, self.hole_diam)
-            .extrude(GR_HOLE_SLICE)
+            .extrude(self.c.GR_HOLE_SLICE)
         )
         xo = self.hole_diam / 2
-        rs = composite_from_pts(rc, [(-xo, 0, GR_HOLE_H), (xo, 0, GR_HOLE_H)])
+        rs = composite_from_pts(rc, [(-xo, 0, self.c.GR_HOLE_H), (xo, 0, self.c.GR_HOLE_H)])
         rs = composite_from_pts(rs, self.hole_centres)
         return obj.union(rs.translate((-self.half_l, self.half_w, 0)))
 

--- a/cqgridfinity/gf_drawer.py
+++ b/cqgridfinity/gf_drawer.py
@@ -49,7 +49,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
         self.width_u = 1
         self.length_th = 10
         self.width_th = 10
-        self.thickness = GR_BASE_HEIGHT
+        self.thickness = self.c.GR_BASE_HEIGHT
         self.chamf_rad = 1.0
         self.show_arrows = True
         self.arrow_h = 0.8
@@ -60,7 +60,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
         self.align_tol = 0.15
         self.align_min = 8
         self.min_margin = 4
-        self.tolerance = GR_TOL
+        self.tolerance = self.c.GR_TOL
         self.front_and_back = True
         for k, v in kwargs.items():
             if k in self.__dict__:
@@ -74,8 +74,8 @@ class GridfinityDrawerSpacer(GridfinityObject):
         The geometry of all the spacer elements is then computed to securely
         centre the Gridfinity baseplate(s) inside the drawer footprint."""
         self.size = length, width
-        lu, wu = (math.floor(x / GRU) for x in (length, width))
-        lg, wg = (x * GRU for x in (lu, wu))
+        lu, wu = (math.floor(x / self.c.GRU) for x in (length, width))
+        lg, wg = (x * self.c.GRU for x in (lu, wu))
         lm, wm = (length - lg) / 2, (width - wg) / 2
         self.size_u = lu, wu
         self.width_th, self.length_th = lm - self.tolerance, wm - self.tolerance
@@ -120,19 +120,19 @@ class GridfinityDrawerSpacer(GridfinityObject):
                 if self.front_and_back:
                     print(
                         "Front/back spacers : %dU wide x %.2f mm +%.2f mm tolerance"
-                        % (self.length_fill / GRU, self.length_th, self.tolerance)
+                        % (self.length_fill / self.c.GRU, self.length_th, self.tolerance)
                     )
                 else:
                     print(
                         "Back spacer        : %dU wide x %.2f mm +%.2f mm tolerance"
-                        % (self.length_fill / GRU, self.fb_length_th, self.tolerance)
+                        % (self.length_fill / self.c.GRU, self.fb_length_th, self.tolerance)
                     )
             else:
                 print("Front/back spacers : not required")
             if self.wide_enough:
                 print(
                     "Left/right spacers : %dU deep x %.2f mm +%.2f mm tolerance"
-                    % (self.width_fill / GRU, self.width_th, self.tolerance)
+                    % (self.width_fill / self.c.GRU, self.width_th, self.tolerance)
                 )
                 if not self.front_and_back:
                     print(
@@ -143,7 +143,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
 
     @property
     def fillet_rad(self):
-        rads = [GR_RAD]
+        rads = [self.c.GR_RAD]
         if self.wide_enough:
             rads.append(self.width_th / 6)
         if self.deep_enough:
@@ -204,7 +204,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
                 .rect(sp_length, self.fb_length_th)
                 .extrude(self.thickness)
             )
-            er = min(GR_RAD, max(self.length_th, self.width_th) / 4)
+            er = min(self.c.GR_RAD, max(self.length_th, self.width_th) / 4)
             r = r.translate((sp_length / 2, self.fb_length_th / 2, 0))
             r = r.edges("|Z").edges("<XY").fillet(er)
             r = r.edges("|Z").fillet(self.fillet_rad)
@@ -215,7 +215,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
             rd = (
                 cq.Workplane("XY").rect(self.width_th, sp_width).extrude(self.thickness)
             )
-            er = min(GR_RAD, max(self.length_th, self.width_th) / 4)
+            er = min(self.c.GR_RAD, max(self.length_th, self.width_th) / 4)
             rd = rd.translate((self.width_th / 2, sp_width / 2, 0))
             rd = rd.edges("|Z").edges("<Y").fillet(er)
             rd = rd.edges("|Z").fillet(self.fillet_rad)
@@ -243,7 +243,7 @@ class GridfinityDrawerSpacer(GridfinityObject):
         x, y = self.align_l, self.fb_length_th / 2
         if not horz:
             y = self.width_th / 2
-        fr = min(GR_RAD / 2, y / 3)
+        fr = min(self.c.GR_RAD / 2, y / 3)
         if as_cutter:
             x += 2 * self.align_tol
             y += 2 * self.align_tol

--- a/cqgridfinity/gf_obj.py
+++ b/cqgridfinity/gf_obj.py
@@ -30,6 +30,8 @@ from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.StlAPI import StlAPI_Writer
 import cadquery as cq
 from cadquery import exporters
+from cqgridfinity.constants import GridfinityConfig, SQRT2
+import cqgridfinity.constants as constants
 
 from cqgridfinity import *
 from cqkit import export_step_file
@@ -52,12 +54,13 @@ class GridfinityObject:
     for derived Gridfinity object classes.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, config: GridfinityConfig | None = None, **kwargs):
         self.length_u = 1
         self.width_u = 1
         self.height_u = 1
         self._cq_obj = None
         self._obj_label = None
+        self.c = config or constants._c
         for k, v in kwargs.items():
             if k in self.__dict__:
                 self.__dict__[k] = v
@@ -70,46 +73,46 @@ class GridfinityObject:
 
     @property
     def length(self):
-        return self.length_u * GRU
+        return self.length_u * self.c.GRU
 
     @property
     def width(self):
-        return self.width_u * GRU
+        return self.width_u * self.c.GRU
 
     @property
     def height(self):
-        return 3.8 + GRHU * self.height_u
+        return 3.8 + self.c.GRHU * self.height_u
 
     @property
     def int_height(self):
-        h = self.height - GR_LIP_H - GR_BOT_H
+        h = self.height - self.c.GR_LIP_H - self.c.GR_BOT_H
         if self.lite_style:
             return h + self.wall_th
         return h
 
     @property
     def max_height(self):
-        return self.int_height + GR_UNDER_H + GR_TOPSIDE_H
+        return self.int_height + self.c.GR_UNDER_H + self.c.GR_TOPSIDE_H
 
     @property
     def floor_h(self):
         if self.lite_style:
-            return GR_FLOOR - self.wall_th
-        return GR_FLOOR
+            return self.c.GR_FLOOR - self.wall_th
+        return self.c.GR_FLOOR
 
     @property
     def lip_width(self):
         if self.no_lip:
             return self.wall_th
-        return GR_UNDER_H + self.wall_th
+        return self.c.GR_UNDER_H + self.wall_th
 
     @property
     def outer_l(self):
-        return self.length_u * GRU - GR_TOL
+        return self.length_u * self.c.GRU - self.c.GR_TOL
 
     @property
     def outer_w(self):
-        return self.width_u * GRU - GR_TOL
+        return self.width_u * self.c.GRU - self.c.GR_TOL
 
     @property
     def outer_dim(self):
@@ -129,11 +132,11 @@ class GridfinityObject:
 
     @property
     def half_l(self):
-        return (self.length_u - 1) * GRU2
+        return (self.length_u - 1) * self.c.GRU2
 
     @property
     def half_w(self):
-        return (self.width_u - 1) * GRU2
+        return (self.width_u - 1) * self.c.GRU2
 
     @property
     def half_dim(self):
@@ -141,11 +144,11 @@ class GridfinityObject:
 
     @property
     def half_in(self):
-        return GRU2 - self.wall_th - GR_TOL / 2
+        return self.c.GRU2 - self.wall_th - self.c.GR_TOL / 2
 
     @property
     def outer_rad(self):
-        return GR_RAD - GR_TOL / 2
+        return self.c.GR_RAD - self.c.GR_TOL / 2
 
     @property
     def inner_rad(self):
@@ -153,18 +156,18 @@ class GridfinityObject:
 
     @property
     def under_h(self):
-        return GR_UNDER_H - (self.wall_th - GR_WALL)
+        return self.c.GR_UNDER_H - (self.wall_th - self.c.GR_WALL)
 
     @property
     def safe_fillet_rad(self):
         if not any([self.scoops, self.labels, self.length_div, self.width_div]):
-            return GR_FILLET
-        return min(GR_FILLET, (GR_UNDER_H + GR_WALL) - self.wall_th - 0.05)
+            return self.c.GR_FILLET
+        return min(self.c.GR_FILLET, (self.c.GR_UNDER_H + self.c.GR_WALL) - self.wall_th - 0.05)
 
     @property
     def grid_centres(self):
         return [
-            (x * GRU, y * GRU)
+            (x * self.c.GRU, y * self.c.GRU)
             for x in range(self.length_u)
             for y in range(self.width_u)
         ]
@@ -172,7 +175,7 @@ class GridfinityObject:
     @property
     def hole_centres(self):
         return [
-            (x * GRU - GR_HOLE_DIST * i, -(y * GRU - GR_HOLE_DIST * j))
+            (x * self.c.GRU - self.c.GR_HOLE_DIST * i, -(y * self.c.GRU - self.c.GR_HOLE_DIST * j))
             for x in range(self.length_u)
             for y in range(self.width_u)
             for i in (-1, 1)
@@ -224,7 +227,7 @@ class GridfinityObject:
                     fn = fn + "x%d" % (self.width_div)
                 else:
                     fn = fn + "_div_x%d" % (self.width_div)
-            if abs(self.wall_th - GR_WALL) > 1e-3:
+            if abs(self.wall_th - self.c.GR_WALL) > 1e-3:
                 fn = fn + "_%.2f" % (self.wall_th)
             if self.no_lip:
                 fn = fn + "_basic"

--- a/cqgridfinity/gf_ruggedbox.py
+++ b/cqgridfinity/gf_ruggedbox.py
@@ -71,9 +71,9 @@ class GridfinityRuggedBox(GridfinityObject):
         self.front_label = True
         self.label_length = None
         self.label_height = None
-        self.label_th = GR_LABEL_TH
+        self.label_th = self.c.GR_LABEL_TH
         self.back_feet = True
-        self.hinge_width = GR_HINGE_SZ
+        self.hinge_width = self.c.GR_HINGE_SZ
         self.hinge_bolted = False
         self.rib_style = False
         self._lid_window = False
@@ -97,52 +97,52 @@ class GridfinityRuggedBox(GridfinityObject):
 
     @property
     def box_length(self):
-        return self.length_u * GRU + 2 * GR_RBOX_WALL
+        return self.length_u * self.c.GRU + 2 * self.c.GR_RBOX_WALL
 
     @property
     def int_length(self):
-        return self.length_u * GRU
+        return self.length_u * self.c.GRU
 
     @property
     def box_width(self):
-        return self.width_u * GRU + 2 * GR_RBOX_WALL
+        return self.width_u * self.c.GRU + 2 * self.c.GR_RBOX_WALL
 
     @property
     def int_width(self):
-        return self.width_u * GRU
+        return self.width_u * self.c.GRU
 
     @property
     def clasp_pos(self):
-        return self.int_length / 2 - GRU2, self.int_width / 2 - GRU2
+        return self.int_length / 2 - self.c.GRU2, self.int_width / 2 - self.c.GRU2
 
     @property
     def box_height(self):
-        return self.height_u * GRHU + 3
+        return self.height_u * self.c.GRHU + 3
 
     @property
     def clasp_heights(self):
-        h0 = GR_RIB_CTR / 2 + GR_RIB_L / 2
-        h1 = h0 + GR_RIB_CTR
-        return [GR_RIB_L / 2, self.box_height - h0, self.box_height - h1]
+        h0 = self.c.GR_RIB_CTR / 2 + self.c.GR_RIB_L / 2
+        h1 = h0 + self.c.GR_RIB_CTR
+        return [self.c.GR_RIB_L / 2, self.box_height - h0, self.box_height - h1]
 
     @property
     def side_clasp_centres(self):
-        xo = self.box_length / 2 + GR_RBOX_CHAN_D / 2
+        xo = self.box_length / 2 + self.c.GR_RBOX_CHAN_D / 2
         yo = self.clasp_pos[1]
         return [(-xo, yo, 0), (xo, yo, 0), (-xo, -yo, 0), (xo, -yo, 0)]
 
     @property
     def front_clasp_centres(self):
         xo = self.clasp_pos[0]
-        yo = self.box_width / 2 + GR_RBOX_CHAN_D / 2
+        yo = self.box_width / 2 + self.c.GR_RBOX_CHAN_D / 2
         return [(-xo, -yo, 0), (xo, -yo, 0)]
 
     @property
     def clasp_notch_points(self):
         return [
             (
-                x * GR_RBOX_CHAN_W / 2,
-                -GR_RBOX_CHAN_D / 2,
+                x * self.c.GR_RBOX_CHAN_W / 2,
+                -self.c.GR_RBOX_CHAN_D / 2,
                 self.box_height - self.lid_height,
             )
             for x in (-1, 1)
@@ -150,16 +150,16 @@ class GridfinityRuggedBox(GridfinityObject):
 
     @property
     def hinge_centres(self):
-        xo = self.box_length / 2 - GR_HINGE_CTR
-        yo = self.box_width / 2 + GR_RBOX_CWALL - GR_RBOX_WALL
+        xo = self.box_length / 2 - self.c.GR_HINGE_CTR
+        yo = self.box_width / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL
         zo = self.box_height
         return [(-xo, yo, zo), (xo, yo, zo)]
 
     @property
     def align_centres(self):
-        ro = GR_RBOX_CHAN_D / 2 - GR_REG_W / 2
-        xo, xc = self.box_length / 2 - GRU, self.box_length / 2 + ro
-        yo, yc = self.box_width / 2 - GRU, self.box_width / 2 + ro
+        ro = self.c.GR_RBOX_CHAN_D / 2 - self.c.GR_REG_W / 2
+        xo, xc = self.box_length / 2 - self.c.GRU, self.box_length / 2 + ro
+        yo, yc = self.box_width / 2 - self.c.GRU, self.box_width / 2 + ro
         pts = [
             (-xo, -yc, 0),
             (xo, -yc, 0),
@@ -174,8 +174,8 @@ class GridfinityRuggedBox(GridfinityObject):
     @property
     def right_qtr_centre(self):
         return (
-            self.box_length / 2 - GR_RBOX_WALL / 2 + 0.125,
-            -self.box_width / 2 + GR_RBOX_WALL / 2 - 0.125,
+            self.box_length / 2 - self.c.GR_RBOX_WALL / 2 + 0.125,
+            -self.box_width / 2 + self.c.GR_RBOX_WALL / 2 - 0.125,
             self.box_height,
         )
 
@@ -188,8 +188,8 @@ class GridfinityRuggedBox(GridfinityObject):
         return self.qtr_centres(tol=0.25)
 
     def qtr_centres(self, tol=0.25, at_height=0, front=True, back=True):
-        xo = self.box_length / 2 - GR_RBOX_WALL / 2 + tol
-        yo = self.box_width / 2 - GR_RBOX_WALL / 2 + tol
+        xo = self.box_length / 2 - self.c.GR_RBOX_WALL / 2 + tol
+        yo = self.box_width / 2 - self.c.GR_RBOX_WALL / 2 + tol
         qd = {}
         if front:
             qd["br"] = (xo, -yo, at_height)
@@ -201,14 +201,14 @@ class GridfinityRuggedBox(GridfinityObject):
 
     @property
     def long_enough_for_handle(self):
-        return self.right_handle_centre[0] > GRU / 2
+        return self.right_handle_centre[0] > self.c.GRU / 2
 
     @property
     def right_handle_centre(self):
         zo = (self.box_height + self.lid_height) / 2
-        if (zo + GR_HANDLE_SZ / 2) > self.box_height:
+        if (zo + self.c.GR_HANDLE_SZ / 2) > self.box_height:
             zo = self.box_height / 2
-        return self.box_length / 2 - GR_HANDLE_OFS, -self.box_width / 2, zo
+        return self.box_length / 2 - self.c.GR_HANDLE_OFS, -self.box_width / 2, zo
 
     @property
     def left_handle_centre(self):
@@ -216,13 +216,13 @@ class GridfinityRuggedBox(GridfinityObject):
 
     @property
     def back_corner_centres(self):
-        xo = self.box_length / 2 - GR_RBOX_BACK_L / 2 + GR_RBOX_CWALL - GR_RBOX_WALL
-        yo = self.box_width / 2 - GR_RBOX_CORNER_W / 2 + GR_RBOX_CWALL - GR_RBOX_WALL
+        xo = self.box_length / 2 - self.c.GR_RBOX_BACK_L / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL
+        yo = self.box_width / 2 - self.c.GR_RBOX_CORNER_W / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL
         return [(-xo, yo, 0), (xo, yo, 0)]
 
     @property
     def front_corner_centres(self):
-        xo = self.box_length / 2 - GR_RBOX_FRONT_L / 2 + GR_RBOX_CWALL - GR_RBOX_WALL
+        xo = self.box_length / 2 - self.c.GR_RBOX_FRONT_L / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL
         yo = -self.back_corner_centres[0][1]
         return [(-xo, yo, 0), (xo, yo, 0)]
 
@@ -246,13 +246,13 @@ class GridfinityRuggedBox(GridfinityObject):
             self.lid_baseplate = False
 
     def lid_window_size(self, width_ext=None, tol=None):
-        tol = tol if tol is not None else GR_TOL
+        tol = tol if tol is not None else self.c.GR_TOL
         width_ext = width_ext if width_ext is not None else 4
         return self.length - 2 - tol, self.width + width_ext - tol
 
     def lid_window_hole_pos(self, z=0):
         pts = [
-            (-x * (self.box_length / 2 - GR_RBOX_CORNER_W), self.width / 2 + 2, z)
+            (-x * (self.box_length / 2 - self.c.GR_RBOX_CORNER_W), self.width / 2 + 2, z)
             for x in (-1, 1)
         ]
         if self.rib_style:
@@ -264,17 +264,17 @@ class GridfinityRuggedBox(GridfinityObject):
         if self.label_length is not None:
             length = self.label_length
         else:
-            length = self.box_length - 2 * GR_RBOX_CORNER_W + (GR_RBOX_CWALL) / 2
+            length = self.box_length - 2 * self.c.GR_RBOX_CORNER_W + (self.c.GR_RBOX_CWALL) / 2
         if self.label_height is not None:
             height = self.label_height
         else:
-            height = GR_LABEL_H
+            height = self.c.GR_LABEL_H
         # ensure the label is not too tall
         if height >= self.box_height:
             height = self.box_height - 5
         # trim label size if handles are enabled
         if self.front_handle and self.long_enough_for_handle:
-            length = length - 2 * (GR_HANDLE_SEP + GR_HANDLE_W)
+            length = length - 2 * (self.c.GR_HANDLE_SEP + self.c.GR_HANDLE_W)
         # return the desired size variant
         if as_insert:
             length -= 5
@@ -287,56 +287,56 @@ class GridfinityRuggedBox(GridfinityObject):
         """General purpose render function for both the box and the lid."""
         height = self.box_height if not as_lid else self.lid_height
         # render overall box shape
-        rs = rounded_rect_sketch(self.box_length, self.box_width, GR_RAD)
+        rs = rounded_rect_sketch(self.box_length, self.box_width, self.c.GR_RAD)
         r = cq.Workplane("XY").placeSketch(rs).extrude(height)
         # back corners
         if self.rib_style:
-            lb = self.box_length + 2 * (GR_RBOX_CWALL - GR_RBOX_WALL)
+            lb = self.box_length + 2 * (self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL)
             yo = self.back_corner_centres[0]
-            rc = cq.Workplane("XY").rect(lb, GR_RBOX_CORNER_W).extrude(height)
+            rc = cq.Workplane("XY").rect(lb, self.c.GR_RBOX_CORNER_W).extrude(height)
             r = r.union(rc.translate((0, yo[1], 0)))
             if not as_lid or (as_lid and not self.side_handles):
                 h = height / 2 if self.side_handles else height
-                wb = self.box_width - GR_RBOX_CORNER_W
+                wb = self.box_width - self.c.GR_RBOX_CORNER_W
                 rc = cq.Workplane("XY").rect(lb, wb).extrude(h)
                 r = r.union(rc)
         else:
             rc = (
                 cq.Workplane("XY")
-                .rect(GR_RBOX_BACK_L, GR_RBOX_CORNER_W)
+                .rect(self.c.GR_RBOX_BACK_L, self.c.GR_RBOX_CORNER_W)
                 .extrude(height)
             )
             r = r.union(composite_from_pts(rc, self.back_corner_centres))
         # front corners
-        rc = cq.Workplane("XY").rect(GR_RBOX_FRONT_L, GR_RBOX_CORNER_W).extrude(height)
+        rc = cq.Workplane("XY").rect(self.c.GR_RBOX_FRONT_L, self.c.GR_RBOX_CORNER_W).extrude(height)
         r = r.union(composite_from_pts(rc, self.front_corner_centres))
         # fillet external edges
         vs = VerticalEdgeSelector()
         cs = StringSyntaxSelector("(<XY) or (>X and <Y) or (<X and >Y) or (>XY)")
-        r = r.edges(vs - cs).fillet(GR_RBOX_RAD).edges(cs).fillet(GR_RBOX_CRAD)
+        r = r.edges(vs - cs).fillet(self.c.GR_RBOX_RAD).edges(cs).fillet(self.c.GR_RBOX_CRAD)
 
         if self.stackable or as_lid:
             # bottom stacking mates
             for k, v in self.qtr_centres(back=not as_lid).items():
                 rq = quarter_circle(
-                    GR_BREG_R0, GR_BREG_R1, GR_REG_H + 0.5, k, chamf=0, ext=0.25
+                    self.c.GR_BREG_R0, self.c.GR_BREG_R1, self.c.GR_REG_H + 0.5, k, chamf=0, ext=0.25
                 )
                 r = r.cut(rq.translate(v))
             pts, rots = self.align_centres
             for pt, rot in zip(pts, rots):
-                rc = chamf_rect(GR_REG_L, GR_REG_W, GR_REG_H, angle=rot)
+                rc = chamf_rect(self.c.GR_REG_L, self.c.GR_REG_W, self.c.GR_REG_H, angle=rot)
                 r = r.cut(rc.translate(pt))
 
         # chamfer top edges
-        r = r.edges(">Z").chamfer(GR_RBOX_VCUT_D)
+        r = r.edges(">Z").chamfer(self.c.GR_RBOX_VCUT_D)
 
         # front lid overhang
         if as_lid:
-            w = min(GR_LID_HANDLE_W, self.box_length - 2 * GR_RBOX_FRONT_L)
+            w = min(self.c.GR_LID_HANDLE_W, self.box_length - 2 * self.c.GR_RBOX_FRONT_L)
             r = r.union(self.lid_handle(width=w).translate((0, -self.box_width / 2, 0)))
             hw = w / 2
             vs = VerticalEdgeSelector([9]) & HasXCoordinateSelector([-hw, hw])
-            r = r.edges(vs).fillet(2.5 - EPS)
+            r = r.edges(vs).fillet(2.5 - self.c.EPS)
 
         # chamfer cuts
         if self.wall_vgrooves:
@@ -346,7 +346,7 @@ class GridfinityRuggedBox(GridfinityObject):
                 r = r.intersect(self.render_vcut())
 
         # chamfer bottom edges
-        r = r.edges("<Z").chamfer(GR_RBOX_VCUT_D)
+        r = r.edges("<Z").chamfer(self.c.GR_RBOX_VCUT_D)
 
         # apply rib style cutouts if applicable
         if self.rib_style and not as_lid:
@@ -381,11 +381,11 @@ class GridfinityRuggedBox(GridfinityObject):
                         r = r.union(rc.rotate_z(90).translate(pt))
             return r
         else:
-            xl = self.box_length + 2 * GR_RBOX_CWALL - 2 * GR_RBOX_WALL
-            yl = self.box_width + 2 * GR_RBOX_CWALL - 2 * GR_RBOX_WALL
-            lead_height = self.lid_height - GR_RBOX_VCUT_D
-            mid_height = self.box_height - 2 * (self.lid_height + GR_RBOX_VCUT_D)
-            cut_half = GR_RBOX_VCUT_D * SQRT2
+            xl = self.box_length + 2 * self.c.GR_RBOX_CWALL - 2 * self.c.GR_RBOX_WALL
+            yl = self.box_width + 2 * self.c.GR_RBOX_CWALL - 2 * self.c.GR_RBOX_WALL
+            lead_height = self.lid_height - self.c.GR_RBOX_VCUT_D
+            mid_height = self.box_height - 2 * (self.lid_height + self.c.GR_RBOX_VCUT_D)
+            cut_half = self.c.GR_RBOX_VCUT_D * SQRT2
             profile = [
                 lead_height,
                 (cut_half, 45),
@@ -395,15 +395,15 @@ class GridfinityRuggedBox(GridfinityObject):
                 (cut_half, -45),
                 lead_height,
             ]
-            rs = rounded_rect_sketch(xl, yl, GR_RBOX_CRAD)
+            rs = rounded_rect_sketch(xl, yl, self.c.GR_RBOX_CRAD)
             return self.extrude_profile(rs, profile)
 
     def rib_style_cut(self):
         """Render cutouts for a rib style box"""
-        xl = self.box_length + 2 * GR_RBOX_CWALL - 2 * GR_RBOX_WALL
-        yl = self.box_width + 2 * GR_RBOX_CWALL - 2 * GR_RBOX_WALL
-        wd = GR_RBOX_CWALL - GR_RBOX_WALL
-        lead_height = self.lid_height - GR_RBOX_VCUT_D
+        xl = self.box_length + 2 * self.c.GR_RBOX_CWALL - 2 * self.c.GR_RBOX_WALL
+        yl = self.box_width + 2 * self.c.GR_RBOX_CWALL - 2 * self.c.GR_RBOX_WALL
+        wd = self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL
+        lead_height = self.lid_height - self.c.GR_RBOX_VCUT_D
         cut_half = wd * SQRT2
         mid_height = self.box_height - 2 * (lead_height + wd)
         profile = [
@@ -413,44 +413,44 @@ class GridfinityRuggedBox(GridfinityObject):
             (cut_half, -45),
             lead_height,
         ]
-        rs = rounded_rect_sketch(xl, yl, GR_RBOX_CRAD)
+        rs = rounded_rect_sketch(xl, yl, self.c.GR_RBOX_CRAD)
         r = self.extrude_profile(rs, profile)
-        w = GR_RBOX_CHAN_W + 3 * GR_RBOX_WALL
-        rc = cq.Workplane("XY").rect(GR_RBOX_CHAN_D, w).extrude(self.box_height)
+        w = self.c.GR_RBOX_CHAN_W + 3 * self.c.GR_RBOX_WALL
+        rc = cq.Workplane("XY").rect(self.c.GR_RBOX_CHAN_D, w).extrude(self.box_height)
         if self.side_clasps:
             for pt in self.side_clasp_centres:
                 r = r.union(rc.translate(pt))
         else:
             rd = (
                 cq.Workplane("XY")
-                .rect(GR_RBOX_CHAN_D, 1.5 * GR_RBOX_WALL)
+                .rect(self.c.GR_RBOX_CHAN_D, 1.5 * self.c.GR_RBOX_WALL)
                 .extrude(self.box_height)
             )
-            xo = self.box_length / 2 + GR_RBOX_CHAN_D / 2
-            yo = self.clasp_pos[1] + GR_RBOX_CHAN_W / 2 + 1.5 * GR_RBOX_WALL / 2
+            xo = self.box_length / 2 + self.c.GR_RBOX_CHAN_D / 2
+            yo = self.clasp_pos[1] + self.c.GR_RBOX_CHAN_W / 2 + 1.5 * self.c.GR_RBOX_WALL / 2
             for pt in [(x * xo, y * yo, 0) for x in (-1, 1) for y in (-1, 1)]:
                 r = r.union(rd.translate(pt))
         rc = rotate_z(rc, 90)
         for pt in self.front_clasp_centres:
             r = r.union(rc.translate(pt))
-        w = 1.5 * GR_RBOX_WALL
+        w = 1.5 * self.c.GR_RBOX_WALL
         rc = cq.Workplane("XY").rect(w, wd).extrude(self.box_height)
         for pt in self.hinge_centres:
-            r = r.union(rc.translate((pt[0] - GR_HINGE_SZ / 2 - w, pt[1] - wd / 2, 0)))
-            r = r.union(rc.translate((pt[0] + GR_HINGE_SZ / 2 + w, pt[1] - wd / 2, 0)))
-        yo = self.box_width / 2 + GR_RBOX_CWALL - GR_RBOX_WALL - wd / 2
+            r = r.union(rc.translate((pt[0] - self.c.GR_HINGE_SZ / 2 - w, pt[1] - wd / 2, 0)))
+            r = r.union(rc.translate((pt[0] + self.c.GR_HINGE_SZ / 2 + w, pt[1] - wd / 2, 0)))
+        yo = self.box_width / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL - wd / 2
         for x in range(self.length_u):
-            xo = -self.int_length / 2 + x * GRU
-            if abs(xo) < (self.box_length / 2 - GR_RBOX_BACK_L):
+            xo = -self.int_length / 2 + x * self.c.GRU
+            if abs(xo) < (self.box_length / 2 - self.c.GR_RBOX_BACK_L):
                 r = r.union(rc.translate((xo, yo, 0)))
         if not self.side_handles:
-            xo = self.box_length / 2 + GR_RBOX_CWALL - GR_RBOX_WALL - wd / 2
+            xo = self.box_length / 2 + self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL - wd / 2
             rc = rotate_z(rc, 90)
             ylim = self.int_width / 2
             if self.side_clasps:
-                ylim -= GR_RBOX_CORNER_W
+                ylim -= self.c.GR_RBOX_CORNER_W
             for y in range(self.width_u):
-                yo = -self.int_width / 2 + y * GRU
+                yo = -self.int_width / 2 + y * self.c.GRU
                 if abs(yo) < ylim:
                     r = r.union(rc.translate((xo, yo, 0)))
                     r = r.union(rc.translate((-xo, yo, 0)))
@@ -460,8 +460,8 @@ class GridfinityRuggedBox(GridfinityObject):
 
     def lid_handle(self, width=None):
         """Renders the front overhanging handle lip for the lid."""
-        width = width if width is not None else GR_LID_HANDLE_W
-        l0, l1, h1, h2, hw = 3, 5, 4, self.lid_height - GR_RBOX_VCUT_D, width / 2
+        width = width if width is not None else self.c.GR_LID_HANDLE_W
+        l0, l1, h1, h2, hw = 3, 5, 4, self.lid_height - self.c.GR_RBOX_VCUT_D, width / 2
         rs = (
             cq.Sketch()
             .segment((l0, 0), (-l1, 0))
@@ -481,10 +481,10 @@ class GridfinityRuggedBox(GridfinityObject):
 
     def side_handle(self, width=None):
         """Renders the handles for the left and right box sides."""
-        width = width if width is not None else GR_LID_HANDLE_W
-        l0, l1, h1, hw = GR_RBOX_WALL, 7, 4, width / 2
-        l2 = GR_RBOX_WALL / 2
-        h2 = self.lid_height - GR_RBOX_VCUT_D + 2
+        width = width if width is not None else self.c.GR_LID_HANDLE_W
+        l0, l1, h1, hw = self.c.GR_RBOX_WALL, 7, 4, width / 2
+        l2 = self.c.GR_RBOX_WALL / 2
+        h2 = self.lid_height - self.c.GR_RBOX_VCUT_D + 2
         # handle shape
         rs = (
             cq.Sketch()
@@ -507,7 +507,7 @@ class GridfinityRuggedBox(GridfinityObject):
         )
         rw = cq.Workplane("YZ").placeSketch(rs).extrude(2.5)
         rw = inverse_fillet(
-            rw, ">Y", 5, (StringSyntaxSelector("<Z") & EdgeLengthSelector(GR_RBOX_WALL))
+            rw, ">Y", 5, (StringSyntaxSelector("<Z") & EdgeLengthSelector(self.c.GR_RBOX_WALL))
         )
         rh = []
         bs = VerticalEdgeSelector() & (HasYCoordinateSelector("<0"))
@@ -522,12 +522,12 @@ class GridfinityRuggedBox(GridfinityObject):
         )
         r = r.edges(bs).chamfer(0.5).translate((-hw, 0, -2))
         r = r.union(rh[2].translate((-hw, 0, -2)))
-        if width > GR_LID_HANDLE_W / 2:
+        if width > self.c.GR_LID_HANDLE_W / 2:
             r = r.union(rh[0].translate((-l2, 0, -2)))
-        r = r.union(rh[1].translate((hw - GR_RBOX_WALL, 0, -2)))
+        r = r.union(rh[1].translate((hw - self.c.GR_RBOX_WALL, 0, -2)))
         vs = VerticalEdgeSelector([h1 - 0.5]) & HasXCoordinateSelector([-hw, hw])
         r = r.edges(vs).fillet(2)
-        vs = VerticalEdgeSelector(2.9) & HasYCoordinateSelector(-l1 + GR_RBOX_WALL)
+        vs = VerticalEdgeSelector(2.9) & HasYCoordinateSelector(-l1 + self.c.GR_RBOX_WALL)
         r = r.edges(vs).fillet(1)
         rc = cq.Workplane("XY").rect(4 * hw, 4 * hw).extrude(self.lid_height + 2 * h2)
         r = r.intersect(rc.translate((0, 0, -2 * h2)))
@@ -535,25 +535,25 @@ class GridfinityRuggedBox(GridfinityObject):
 
     def label_slot(self):
         """Renders the front label holder."""
-        rs = rounded_rect_sketch(*self.label_size(), GR_RAD)
-        r = self.extrude_profile(rs, [(GR_LABEL_SLOT_TH * SQRT2, 45)], workplane="XZ")
+        rs = rounded_rect_sketch(*self.label_size(), self.c.GR_RAD)
+        r = self.extrude_profile(rs, [(self.c.GR_LABEL_SLOT_TH * SQRT2, 45)], workplane="XZ")
         rc = (
             cq.Workplane("XZ")
             .rect(*self.label_size(as_aperture=True))
-            .extrude(GR_LABEL_SLOT_TH)
+            .extrude(self.c.GR_LABEL_SLOT_TH)
         )
-        r = r.cut(rc.edges(EdgeLengthSelector(GR_LABEL_SLOT_TH)).chamfer(2.5))
+        r = r.cut(rc.edges(EdgeLengthSelector(self.c.GR_LABEL_SLOT_TH)).chamfer(2.5))
         xl, yl = self.label_size(as_insert=True)
         xl -= 8
-        rc = cq.Workplane("XZ").rect(xl, yl).extrude(GR_LABEL_SLOT_TH)
+        rc = cq.Workplane("XZ").rect(xl, yl).extrude(self.c.GR_LABEL_SLOT_TH)
         r = r.cut(rc.translate((0, 0, 5)))
         rc = (
             cq.Workplane("XZ")
             .rect(*self.label_size(as_insert=True))
-            .extrude(GR_LABEL_SLOT_TH / 2)
+            .extrude(self.c.GR_LABEL_SLOT_TH / 2)
         )
-        rc = rc.edges("|Y and <Z").fillet(GR_LABEL_SLOT_TH / 2)
-        r = r.cut(rc.translate((0, 0, GR_LABEL_SLOT_TH)))
+        rc = rc.edges("|Y and <Z").fillet(self.c.GR_LABEL_SLOT_TH / 2)
+        r = r.cut(rc.translate((0, 0, self.c.GR_LABEL_SLOT_TH)))
 
         # simple restraining ramps to prevent the label slipping out
         rc = (
@@ -561,7 +561,7 @@ class GridfinityRuggedBox(GridfinityObject):
             .rect(10, 2.5)
             .extrude(1.25)
             .edges("<Y")
-            .chamfer(1.25 - EPS)
+            .chamfer(1.25 - self.c.EPS)
         )
         pts = [(-xl / 4, 0, yl / 2 - 2.0), (xl / 4, 0, yl / 2 - 2.0)]
         if self.length_u < 5:
@@ -572,7 +572,7 @@ class GridfinityRuggedBox(GridfinityObject):
 
     def render_label(self):
         """Renders a label panel insert"""
-        rs = rounded_rect_sketch(*self.label_size(tol=3), GR_RAD)
+        rs = rounded_rect_sketch(*self.label_size(tol=3), self.c.GR_RAD)
         r = cq.Workplane("XZ").placeSketch(rs).extrude(self.label_th)
         self._obj_label = "label"
         self._cq_obj = r
@@ -580,41 +580,41 @@ class GridfinityRuggedBox(GridfinityObject):
 
     def clasp_cut(self, as_lid=False):
         """Renders the vertical channel where the clasps / latch are installed."""
-        height = GR_CLASP_SLIDE_D + 6 if as_lid else self.box_height
-        w = GR_RBOX_CHAN_W + GR_CLASP_SLIDE_W
-        rs = cq.Sketch().slot(GR_CLASP_SLIDE_D, GR_CLASP_SLIDE_W, angle=90)
+        height = self.c.GR_CLASP_SLIDE_D + 6 if as_lid else self.box_height
+        w = self.c.GR_RBOX_CHAN_W + self.c.GR_CLASP_SLIDE_W
+        rs = cq.Sketch().slot(self.c.GR_CLASP_SLIDE_D, self.c.GR_CLASP_SLIDE_W, angle=90)
         rs = cq.Workplane("XZ").placeSketch(rs).extrude(w).translate((0, w / 2, 0))
-        rc = cq.Workplane("XY").rect(GR_RBOX_CHAN_D, GR_RBOX_CHAN_W).extrude(height)
-        zo = -GR_CLASP_SLIDE_D / 2 + GR_CLASP_SLIDE_W / 2
+        rc = cq.Workplane("XY").rect(self.c.GR_RBOX_CHAN_D, self.c.GR_RBOX_CHAN_W).extrude(height)
+        zo = -self.c.GR_CLASP_SLIDE_D / 2 + self.c.GR_CLASP_SLIDE_W / 2
         # ensure clasp channel is deep enough for box heights <6U
-        height = max(height, GR_CLASP_SLIDE_D + 5.2)
+        height = max(height, self.c.GR_CLASP_SLIDE_D + 5.2)
         pts = [(0, 0, height + zo), (0, 0, zo)]
         return rc.union(composite_from_pts(rs, pts))
 
     def clasp_rib(self, chamfered=False):
         """Renders a single clasp rib feature."""
-        r = cq.Workplane("XY").rect(GR_RIB_L, GR_RIB_W).extrude(GR_RIB_H)
+        r = cq.Workplane("XY").rect(self.c.GR_RIB_L, self.c.GR_RIB_W).extrude(self.c.GR_RIB_H)
         r = r.faces(">Z").edges("<X or >X").chamfer(1.0)
         if chamfered:
             rc = (
                 cq.Workplane("XZ")
                 .moveTo(0, 0)
-                .lineTo(0, GR_RIB_H)
-                .lineTo(GR_RIB_L / 6, GR_RIB_H)
+                .lineTo(0, self.c.GR_RIB_H)
+                .lineTo(self.c.GR_RIB_L / 6, self.c.GR_RIB_H)
                 .close()
-                .extrude(GR_RIB_W)
+                .extrude(self.c.GR_RIB_W)
             )
-            r = r.cut(rc.translate((-GR_RIB_L / 1.85, GR_RIB_W / 2, 0)))
-            rc = cq.Workplane("XY").rect(GR_RIB_L / 2, GR_RIB_W).extrude(GR_RIB_H / 3)
-            rc = rc.faces(">Z").edges("<X or >X").chamfer(GR_RIB_H / 3 - EPS)
-            r = r.union(rc.translate((-GR_RIB_L / 2.33, 0, 0)))
+            r = r.cut(rc.translate((-self.c.GR_RIB_L / 1.85, self.c.GR_RIB_W / 2, 0)))
+            rc = cq.Workplane("XY").rect(self.c.GR_RIB_L / 2, self.c.GR_RIB_W).extrude(self.c.GR_RIB_H / 3)
+            rc = rc.faces(">Z").edges("<X or >X").chamfer(self.c.GR_RIB_H / 3 - self.c.EPS)
+            r = r.union(rc.translate((-self.c.GR_RIB_L / 2.33, 0, 0)))
         return r
 
     def clasp_ribs(self, side="left", as_lid=False):
         """Renders a group of clasp ribs for any side for both the box and lid."""
-        y1 = GR_RIB_SEP / 2 + GR_RIB_W / 2
-        y2 = y1 + GR_RIB_W + GR_RIB_GAP
-        zo = -GR_RBOX_CHAN_D / 2
+        y1 = self.c.GR_RIB_SEP / 2 + self.c.GR_RIB_W / 2
+        y2 = y1 + self.c.GR_RIB_W + self.c.GR_RIB_GAP
+        zo = -self.c.GR_RBOX_CHAN_D / 2
         pts = [(0, -y2, zo), (0, -y1, zo), (0, y1, zo), (0, y2, zo)]
         rh = composite_from_pts(self.clasp_rib(), pts)
         rc = composite_from_pts(self.clasp_rib(chamfered=True), pts)
@@ -637,41 +637,41 @@ class GridfinityRuggedBox(GridfinityObject):
         """Mounting features for front handle"""
 
         def _bracket(small_hole=False, side="left"):
-            l1 = GR_HANDLE_L1 / 2
-            l2 = min(GR_HANDLE_L2 / 2, (self.box_height - 6) / 2)
-            d2 = M3_DIAM / 2 if small_hole else M3_CLR_DIAM / 2
+            l1 = self.c.GR_HANDLE_L1 / 2
+            l2 = min(self.c.GR_HANDLE_L2 / 2, (self.box_height - 6) / 2)
+            d2 = self.c.M3_DIAM / 2 if small_hole else self.c.M3_CLR_DIAM / 2
             rs = (
                 cq.Sketch()
                 .segment((0, 0), (-l2, 0))
-                .segment((-l1, GR_HANDLE_H))
-                .segment((l1, GR_HANDLE_H))
+                .segment((-l1, self.c.GR_HANDLE_H))
+                .segment((l1, self.c.GR_HANDLE_H))
                 .segment((l2, 0))
                 .close()
                 .assemble()
                 .vertices(">Y")
                 .vertices("<X or >X")
-                .fillet(GR_RAD)
+                .fillet(self.c.GR_RAD)
                 .reset()
-                .push([(0, GR_HANDLE_H / 2)])
+                .push([(0, self.c.GR_HANDLE_H / 2)])
                 .circle(d2, mode="s")
             )
-            r = cq.Workplane("YZ").placeSketch(rs).extrude(GR_HANDLE_W)
+            r = cq.Workplane("YZ").placeSketch(rs).extrude(self.c.GR_HANDLE_W)
             if not small_hole:
                 face = ">X" if side == "left" else "<X"
                 r = (
                     r.faces(face)
                     .workplane()
-                    .pushPoints([(0, GR_HANDLE_H / 2)])
-                    .hole(M3_CB_DIAM, M3_CB_DEPTH)
+                    .pushPoints([(0, self.c.GR_HANDLE_H / 2)])
+                    .hole(self.c.M3_CB_DIAM, self.c.M3_CB_DEPTH)
                 )
 
-            r = inverse_fillet(r, "<Z", GR_RAD, EdgeLengthSelector(GR_HANDLE_W))
+            r = inverse_fillet(r, "<Z", self.c.GR_RAD, EdgeLengthSelector(self.c.GR_HANDLE_W))
             r = r.faces(">Z").chamfer(0.75)
             return rotate_x(r, 90)
 
         h1 = _bracket(small_hole=True, side=side)
         h2 = _bracket(small_hole=False, side=side)
-        xo = GR_HANDLE_SEP if side == "left" else -GR_HANDLE_SEP
+        xo = self.c.GR_HANDLE_SEP if side == "left" else -self.c.GR_HANDLE_SEP
         r = recentre(h1.union(h2.translate((xo, 0, 0))), "xz")
         return r
 
@@ -682,7 +682,7 @@ class GridfinityRuggedBox(GridfinityObject):
         if not self.long_enough_for_handle:
             print("Rugged box length dimension too small to include a handle")
             return None
-        wt, h, rh = GR_HANDLE_TH, GR_HANDLE_SZ, GR_HANDLE_RAD
+        wt, h, rh = self.c.GR_HANDLE_TH, self.c.GR_HANDLE_SZ, self.c.GR_HANDLE_RAD
         lt, ht = (2 * x2) - 2 * rh, h - rh - wt / 2
         path = {
             "start": "(%f,%f) dir:-90 width:%f" % (x2, h, wt),
@@ -690,10 +690,10 @@ class GridfinityRuggedBox(GridfinityObject):
         }
         cw = Ribbon("XZ", path)
         cw.direction = -90
-        r = cw.render().extrude(wt).faces(">Z").edges("|X").fillet(wt / 2 - EPS)
+        r = cw.render().extrude(wt).faces(">Z").edges("|X").fillet(wt / 2 - self.c.EPS)
         r = recentre(r.edges().chamfer(1), "XY")
-        rc = cq.Workplane("YZ").circle(M3_CLR_DIAM / 2).extrude(8 * lt)
-        r = r.cut(rc.translate((-4 * lt, 0, h - M3_CLR_DIAM)))
+        rc = cq.Workplane("YZ").circle(self.c.M3_CLR_DIAM / 2).extrude(8 * lt)
+        r = r.cut(rc.translate((-4 * lt, 0, h - self.c.M3_CLR_DIAM)))
         self._obj_label = "handle"
         self._cq_obj = r
         return self._cq_obj
@@ -701,28 +701,28 @@ class GridfinityRuggedBox(GridfinityObject):
     def render_back_foot(self):
         """Renders a corresponding rear foot the same depth as the hinge for standing
         the box vertically."""
-        rs = cq.Sketch().slot(2 * GR_HINGE_OFFS, 2 * GR_HINGE_RAD, 0)
+        rs = cq.Sketch().slot(2 * self.c.GR_HINGE_OFFS, 2 * self.c.GR_HINGE_RAD, 0)
         rc = cq.Workplane("YZ").placeSketch(rs).extrude(self.hinge_width - 0.4)
-        return recentre(rc).edges().chamfer(1).translate((0, 0, GR_HINGE_RAD))
+        return recentre(rc).edges().chamfer(1).translate((0, 0, self.c.GR_HINGE_RAD))
 
     def hinge_mount(self):
         """Mounting cutout for hinge"""
         l1, l2, l3 = self.hinge_width + 2, self.hinge_width, (self.hinge_width - 2) / 2
-        r = cq.Workplane("XY").rect(l1, GR_HINGE_W1).extrude(GR_HINGE_H1)
-        r = r.translate((0, -GR_HINGE_W1 / 2, -GR_HINGE_H1))
-        r2 = cq.Workplane("XY").rect(l2, GR_HINGE_W2).extrude(GR_HINGE_H2)
-        r2 = r2.translate((0, -GR_HINGE_D - GR_HINGE_W2 / 2, -GR_HINGE_H2))
-        bs = HasZCoordinateSelector(-GR_HINGE_H1) & EdgeLengthSelector(
-            [l2, GR_HINGE_W2]
+        r = cq.Workplane("XY").rect(l1, self.c.GR_HINGE_W1).extrude(self.c.GR_HINGE_H1)
+        r = r.translate((0, -self.c.GR_HINGE_W1 / 2, -self.c.GR_HINGE_H1))
+        r2 = cq.Workplane("XY").rect(l2, self.c.GR_HINGE_W2).extrude(self.c.GR_HINGE_H2)
+        r2 = r2.translate((0, -self.c.GR_HINGE_D - self.c.GR_HINGE_W2 / 2, -self.c.GR_HINGE_H2))
+        bs = HasZCoordinateSelector(-self.c.GR_HINGE_H1) & EdgeLengthSelector(
+            [l2, self.c.GR_HINGE_W2]
         )
         r = r.union(r2).edges(bs).edges(">Y or <X or >X").chamfer(0.75)
-        rs = rounded_rect_sketch(l3, GR_HINGE_W3, 0.5)
-        r3 = cq.Workplane("XY").placeSketch(rs).extrude(GR_HINGE_H2)
-        xo, yo = GR_HINGE_SEP / 2 + l3 / 2, -GR_HINGE_W1 - 1.2 - GR_HINGE_W3 / 2
+        rs = rounded_rect_sketch(l3, self.c.GR_HINGE_W3, 0.5)
+        r3 = cq.Workplane("XY").placeSketch(rs).extrude(self.c.GR_HINGE_H2)
+        xo, yo = self.c.GR_HINGE_SEP / 2 + l3 / 2, -self.c.GR_HINGE_W1 - 1.2 - self.c.GR_HINGE_W3 / 2
         rh = self.hex_cut().translate(
-            (0, 0, GR_HINGE_H2 - GR_HINGE_H1 - GR_HEX_H / 2 + GR_HINGE_SKEW)
+            (0, 0, self.c.GR_HINGE_H2 - self.c.GR_HINGE_H1 - self.c.GR_HEX_H / 2 + self.c.GR_HINGE_SKEW)
         )
-        for pt in [(-xo, yo, -GR_HINGE_H2), (xo, yo, -GR_HINGE_H2)]:
+        for pt in [(-xo, yo, -self.c.GR_HINGE_H2), (xo, yo, -self.c.GR_HINGE_H2)]:
             r = r.union(r3.translate(pt))
             r = r.union(rh.translate(pt))
         return r
@@ -732,7 +732,7 @@ class GridfinityRuggedBox(GridfinityObject):
         l1 = 2 if depth is None else 1.7
         l2 = 3.5 if depth is None else 3.0
         d = depth if depth is not None else 4.0
-        h = GR_HEX_H if depth is None else GR_HEX_H - 0.4
+        h = self.c.GR_HEX_H if depth is None else self.c.GR_HEX_H - 0.4
         rs = (
             cq.Sketch()
             .segment((0, 0), (-l1, 0))
@@ -746,32 +746,32 @@ class GridfinityRuggedBox(GridfinityObject):
         )
         r = cq.Workplane("XZ").placeSketch(rs).extrude(d).translate((0, d, -h / 2))
         if depth is not None:
-            r = r.edges("<Z and >Y").chamfer(depth - EPS)
+            r = r.edges("<Z and >Y").chamfer(depth - self.c.EPS)
         return r
 
     def render_latch(self):
         """Renders the latch element used to secure the box and the lid."""
-        l2, w2, h2 = GR_LATCH_L / 2, GR_LATCH_W / 2, GR_LATCH_H / 2
-        c2, th = GR_RIB_CTR / 2, 2.5
-        hf = GR_LATCH_H - th
+        l2, w2, h2 = self.c.GR_LATCH_L / 2, self.c.GR_LATCH_W / 2, self.c.GR_LATCH_H / 2
+        c2, th = self.c.GR_RIB_CTR / 2, 2.5
+        hf = self.c.GR_LATCH_H - th
         yc = (-1.575, 1.575)
-        r = cq.Workplane("XY").rect(GR_LATCH_L, GR_LATCH_W).extrude(GR_LATCH_H)
+        r = cq.Workplane("XY").rect(self.c.GR_LATCH_L, self.c.GR_LATCH_W).extrude(self.c.GR_LATCH_H)
         r = r.edges("|Y").edges(">X").chamfer(1.0)
-        rs = cq.Sketch().slot(10, GR_LATCH_H, 0)
-        rc = cq.Workplane("XZ").placeSketch(rs).extrude(GR_LATCH_W)
+        rs = cq.Sketch().slot(10, self.c.GR_LATCH_H, 0)
+        rc = cq.Workplane("XZ").placeSketch(rs).extrude(self.c.GR_LATCH_W)
         r = r.union(rc.translate((-l2 + 4.5, w2, h2)))
         rc = cq.Workplane("XY").rect(16, 15.6).extrude(10).edges("|Z").fillet(4.0)
         r = r.cut(rc.translate((-l2 - 8, 0, 0)))
 
-        rc = cq.Workplane("XY").rect(5, GR_LATCH_W - 2.4).extrude(10)
+        rc = cq.Workplane("XY").rect(5, self.c.GR_LATCH_W - 2.4).extrude(10)
         rc = rc.faces("<Z").edges("|X").fillet(1.5).edges("|Z").fillet(1.0)
         r = r.cut(rc.translate((l2, 0, 2.0))).edges().chamfer(0.25)
 
-        rc = cq.Workplane("XY").rect(GR_LATCH_IL, GR_LATCH_IW).extrude(hf)
-        for x in (-GR_RIB_CTR, 0, GR_RIB_CTR):
+        rc = cq.Workplane("XY").rect(self.c.GR_LATCH_IL, self.c.GR_LATCH_IW).extrude(hf)
+        for x in (-self.c.GR_RIB_CTR, 0, self.c.GR_RIB_CTR):
             r = r.cut(rc.translate((x - 1.25, 0, th)))
-        r = r.faces(">Z").edges(EdgeLengthSelector(GR_LATCH_IW)).chamfer(1.5)
-        r = r.faces(">Z").edges(EdgeLengthSelector(GR_LATCH_IL)).chamfer(0.25)
+        r = r.faces(">Z").edges(EdgeLengthSelector(self.c.GR_LATCH_IW)).chamfer(1.5)
+        r = r.faces(">Z").edges(EdgeLengthSelector(self.c.GR_LATCH_IL)).chamfer(0.25)
 
         rc = cq.Workplane("XY").rect(20, 2.4).extrude(hf)
         r = r.cut(rc.translate((0, 0, th)))
@@ -791,7 +791,7 @@ class GridfinityRuggedBox(GridfinityObject):
             for pt in [(x, y, th) for y in yc]:
                 r = r.union(rx.translate(pt))
 
-        rc = cq.Workplane("XZ").rect(2, 3.2).extrude(0.6).edges("<Y").chamfer(0.6 - EPS)
+        rc = cq.Workplane("XZ").rect(2, 3.2).extrude(0.6).edges("<Y").chamfer(0.6 - self.c.EPS)
         xo = xm - self.lid_height
         for angle, y in [(0, -w2), (180, w2)]:
             r = r.union(rotate_z(rc, angle).translate((xo, y, h2)))
@@ -802,7 +802,7 @@ class GridfinityRuggedBox(GridfinityObject):
         r = (
             r.edges(HasYCoordinateSelector([-w2, w2], min_points=2))
             .edges(EdgeLengthSelector([6.0, 0.4]))
-            .chamfer(0.3 - EPS)
+            .chamfer(0.3 - self.c.EPS)
         )
 
         rc = cq.Workplane("XZ").circle(3.8 / 2).extrude(2).faces("<Y").chamfer(0.5)
@@ -817,14 +817,14 @@ class GridfinityRuggedBox(GridfinityObject):
     def render_hinge(self, as_closed=False, section=None):
         """Renders the rear hinge."""
         tol = 0.125
-        cl = 2 * (GR_HINGE_OFFS + GR_HINGE_D + GR_HINGE_W2 / 2)
-        wh, dh = GR_HINGE_W2 - GR_HINGE_TOL, GR_HINGE_H2 - 1
-        ls, ws = cl / 2, GR_HINGE_H1 - GR_HINGE_TOL
-        h = self.hinge_width - GR_HINGE_TOL
+        cl = 2 * (self.c.GR_HINGE_OFFS + self.c.GR_HINGE_D + self.c.GR_HINGE_W2 / 2)
+        wh, dh = self.c.GR_HINGE_W2 - self.c.GR_HINGE_TOL, self.c.GR_HINGE_H2 - 1
+        ls, ws = cl / 2, self.c.GR_HINGE_H1 - self.c.GR_HINGE_TOL
+        h = self.hinge_width - self.c.GR_HINGE_TOL
         h3 = h / 3
         ha, hb, hc, hd = h3 - tol, h3 + tol, 2 * h3 - tol, 2 * h3 + tol
-        cro, cri, crb, crs = GR_HINGE_RAD + GR_HINGE_TOL, GR_HINGE_RAD, 4.5 / 2, 4.0 / 2
-        ctr = (cl / 2 + wh / 2, -GR_HINGE_SKEW)
+        cro, cri, crb, crs = self.c.GR_HINGE_RAD + self.c.GR_HINGE_TOL, self.c.GR_HINGE_RAD, 4.5 / 2, 4.0 / 2
+        ctr = (cl / 2 + wh / 2, -self.c.GR_HINGE_SKEW)
 
         def _bracket(side="left"):
             xo = wh / 2 if side == "left" else cl + wh / 2
@@ -862,20 +862,20 @@ class GridfinityRuggedBox(GridfinityObject):
         if not self.hinge_bolted:
             rr = rr.union(chamf_cyl(crs, h, 0).translate((*ctr, 0)))
         else:
-            rr = rr.cut(chamf_cyl(M3_DIAM / 2, h, 0).translate((*ctr, 0)))
-            rl = rl.cut(chamf_cyl(M3_CLR_DIAM / 2, h, 0).translate((*ctr, 0)))
-            rr = rr.cut(chamf_cyl(M3_CLR_DIAM / 2, ha, 0).translate((*ctr, h - ha)))
+            rr = rr.cut(chamf_cyl(self.c.M3_DIAM / 2, h, 0).translate((*ctr, 0)))
+            rl = rl.cut(chamf_cyl(self.c.M3_CLR_DIAM / 2, h, 0).translate((*ctr, 0)))
+            rr = rr.cut(chamf_cyl(self.c.M3_CLR_DIAM / 2, ha, 0).translate((*ctr, h - ha)))
             rr = rr.cut(
-                chamf_cyl(M3_CB_DIAM / 2, M3_CB_DEPTH, 0).translate(
-                    (*ctr, h - M3_CB_DEPTH)
+                chamf_cyl(self.c.M3_CB_DIAM / 2, self.c.M3_CB_DEPTH, 0).translate(
+                    (*ctr, h - self.c.M3_CB_DEPTH)
                 )
             )
-        rx = recentre(self.hex_cut(depth=GR_HEX_D))
+        rx = recentre(self.hex_cut(depth=self.c.GR_HEX_D))
         rh = rotate_x(rotate_z(rx, 90), 90)
-        xo = cl + wh + GR_HEX_D / 2
-        yo = GR_HINGE_H1 + GR_HEX_H / 2 - 2 * GR_HINGE_SKEW
-        zo = GR_HINGE_SEP / 2 + (self.hinge_width - 2) / 4
-        for pt in [(-GR_HEX_D / 2, yo, h / 2 - z) for z in (-zo, zo)]:
+        xo = cl + wh + self.c.GR_HEX_D / 2
+        yo = self.c.GR_HINGE_H1 + self.c.GR_HEX_H / 2 - 2 * self.c.GR_HINGE_SKEW
+        zo = self.c.GR_HINGE_SEP / 2 + (self.hinge_width - 2) / 4
+        for pt in [(-self.c.GR_HEX_D / 2, yo, h / 2 - z) for z in (-zo, zo)]:
             rl = rl.union(rh.translate(pt))
         rh = rotate_x(rotate_z(rx, -90), 90)
         for pt in [(xo, yo, h / 2 - z) for z in (-zo, zo)]:
@@ -899,27 +899,27 @@ class GridfinityRuggedBox(GridfinityObject):
         # hollow out
         rc = (
             cq.Workplane("XY")
-            .placeSketch(rounded_rect_sketch(self.length, self.width, GR_RAD))
-            .extrude(self.box_height - GR_RBOX_FLOOR)
+            .placeSketch(rounded_rect_sketch(self.length, self.width, self.c.GR_RAD))
+            .extrude(self.box_height - self.c.GR_RBOX_FLOOR)
         )
-        r = r.cut(rc.translate((0, 0, GR_RBOX_FLOOR)))
+        r = r.cut(rc.translate((0, 0, self.c.GR_RBOX_FLOOR)))
 
         # add registration features
         pts, rots = self.align_centres
         for pt, rot in zip(pts, rots):
             rc = chamf_rect(
-                GR_REG_L,
-                GR_REG_W,
-                GR_REG_H,
+                self.c.GR_REG_L,
+                self.c.GR_REG_W,
+                self.c.GR_REG_H,
                 angle=rot,
                 z_offset=self.box_height,
                 tol=0.75,
             )
             r = r.union(rc.translate(pt))
 
-        rq = quarter_circle(GR_REG_R0, GR_REG_R1, GR_REG_H, "bl")
+        rq = quarter_circle(self.c.GR_REG_R0, self.c.GR_REG_R1, self.c.GR_REG_H, "bl")
         r = r.union(rq.translate(self.left_qtr_centre))
-        rq = quarter_circle(GR_REG_R0, GR_REG_R1, GR_REG_H, "br")
+        rq = quarter_circle(self.c.GR_REG_R0, self.c.GR_REG_R1, self.c.GR_REG_H, "br")
         r = r.union(rq.translate(self.right_qtr_centre))
 
         # add handle mounts
@@ -938,7 +938,7 @@ class GridfinityRuggedBox(GridfinityObject):
 
         # add side handles
         if self.side_handles:
-            w = min(GR_SIDE_HANDLE_W, self.box_width - 2 * GR_RBOX_CORNER_W)
+            w = min(self.c.GR_SIDE_HANDLE_W, self.box_width - 2 * self.c.GR_RBOX_CORNER_W)
             rh = self.side_handle(width=w)
             rl = rotate_z(rh, -90)
             rr = rotate_z(rh, 90)
@@ -962,11 +962,11 @@ class GridfinityRuggedBox(GridfinityObject):
         # add baseplate
         if self.inside_baseplate:
             rb = GridfinityBaseplate(self.length_u, self.width_u, ext_depth=1.6)
-            r = r.union(rb.render().translate((0, 0, GR_RBOX_FLOOR)))
-            r = r.edges(FlatEdgeSelector(GR_RBOX_FLOOR)).chamfer(0.8)
+            r = r.union(rb.render().translate((0, 0, self.c.GR_RBOX_FLOOR)))
+            r = r.edges(FlatEdgeSelector(self.c.GR_RBOX_FLOOR)).chamfer(0.8)
         else:
             rb = self.extrude_profile(
-                rounded_rect_sketch(self.length, self.width, GR_RAD), [GR_RBOX_WALL]
+                rounded_rect_sketch(self.length, self.width, self.c.GR_RAD), [self.c.GR_RBOX_WALL]
             )
             r = r.union(rb)
         self._cq_obj = r
@@ -980,7 +980,7 @@ class GridfinityRuggedBox(GridfinityObject):
 
         if self.lid_baseplate:
             # hollow out top half
-            rs = rounded_rect_sketch(self.length - GR_TOL, self.width - GR_TOL, GR_RAD)
+            rs = rounded_rect_sketch(self.length - self.c.GR_TOL, self.width - self.c.GR_TOL, self.c.GR_RAD)
             rc = self.extrude_profile(rs, [self.lid_height - 0.5, (1.0, -45)])
             r = r.cut(rc)
             # add topside baseplate
@@ -991,12 +991,12 @@ class GridfinityRuggedBox(GridfinityObject):
             r = r.union(rb.translate((0, 0, 4.7 - 0.4)))
         elif self.lid_window:
             # hollow out completely
-            rs = rounded_rect_sketch(self.length, self.width, GR_RAD)
+            rs = rounded_rect_sketch(self.length, self.width, self.c.GR_RAD)
             rc = self.extrude_profile(rs, [5])
             r = r.cut(rc)
 
         # hollow out bottom
-        rs = rounded_rect_sketch(self.length, self.width, GR_RAD)
+        rs = rounded_rect_sketch(self.length, self.width, self.c.GR_RAD)
         r = r.cut(cq.Workplane("XY").placeSketch(rs).extrude(4.6))
 
         # add modified bottom extrusion with a looser fit
@@ -1012,8 +1012,8 @@ class GridfinityRuggedBox(GridfinityObject):
             )
         ra = composite_from_pts(rs, self.grid_centres)
         ra = ra.translate((-self.half_l, -self.half_w, 0))
-        rs = rounded_rect_sketch(self.length, self.width, GR_RAD)
-        ra = ra.intersect(cq.Workplane("XY").placeSketch(rs).extrude(GR_LID_WINDOW_H))
+        rs = rounded_rect_sketch(self.length, self.width, self.c.GR_RAD)
+        ra = ra.intersect(cq.Workplane("XY").placeSketch(rs).extrude(self.c.GR_LID_WINDOW_H))
 
         r = r.union(ra)
         r = r.edges(
@@ -1023,13 +1023,13 @@ class GridfinityRuggedBox(GridfinityObject):
         # add optional stackable features
         if self.stackable:
             for k, v in self.qtr_centres(tol=0.125, at_height=self.lid_height).items():
-                rq = quarter_circle(GR_REG_R0, GR_REG_R1, GR_REG_H, k)
+                rq = quarter_circle(self.c.GR_REG_R0, self.c.GR_REG_R1, self.c.GR_REG_H, k)
                 r = r.union(rq.translate(v))
 
         if self.lid_window:
             # hollow the grid apertures
-            ht, tp = GR_LID_WINDOW_H, 34
-            he = GR_LID_WINDOW_H / math.cos(math.radians(tp))
+            ht, tp = self.c.GR_LID_WINDOW_H, 34
+            he = self.c.GR_LID_WINDOW_H / math.cos(math.radians(tp))
             rs = (
                 cq.Workplane("XY")
                 .placeSketch(rounded_rect_sketch(30, 30, 1))
@@ -1043,7 +1043,7 @@ class GridfinityRuggedBox(GridfinityObject):
             ext = 20
             l, w = self.lid_window_size(width_ext=-2 + ext, tol=0)
             rs = rounded_rect_sketch(l, w, 0.5)
-            hlw = self.lid_height - GR_LID_WINDOW_H
+            hlw = self.lid_height - self.c.GR_LID_WINDOW_H
             ht = hlw - self.window_th - 0.5
             rc = (
                 cq.Workplane("XY")
@@ -1058,8 +1058,8 @@ class GridfinityRuggedBox(GridfinityObject):
             )
             rc = rc.edges(VerticalEdgeSelector()).fillet(0.5)
             # rc = self.extrude_profile(rs, [self.window_th, (ht, 60), hlw], angle=True)
-            r = r.cut(rc.translate((0, ext / 2, GR_LID_WINDOW_H)))
-            rs = rounded_rect_sketch(self.length - 5, self.width - 5, GR_RAD)
+            r = r.cut(rc.translate((0, ext / 2, self.c.GR_LID_WINDOW_H)))
+            rs = rounded_rect_sketch(self.length - 5, self.width - 5, self.c.GR_RAD)
             rc = self.extrude_profile(rs, [self.lid_height])
             r = r.cut(rc.translate((0, 0, self.lid_height - ht)))
 
@@ -1072,7 +1072,7 @@ class GridfinityRuggedBox(GridfinityObject):
         if self.lid_window:
             rc = (
                 cq.Workplane("XY")
-                .circle(M2_DIAM / 2)
+                .circle(self.c.M2_DIAM / 2)
                 .extrude(5)
                 .faces(">Z")
                 .wires()
@@ -1091,7 +1091,7 @@ class GridfinityRuggedBox(GridfinityObject):
         rs = rounded_rect_sketch(*self.lid_window_size(), 0.5)
         r = cq.Workplane("XY").placeSketch(rs).extrude(self.window_th)
         r = r.translate((0, 3, 0))
-        rc = cq.Workplane("XY").circle(M2_CLR_DIAM / 2).extrude(self.window_th)
+        rc = cq.Workplane("XY").circle(self.c.M2_CLR_DIAM / 2).extrude(self.window_th)
         for pt in self.lid_window_hole_pos(z=0):
             r = r.cut(rc.translate(pt))
         self._cq_obj = r
@@ -1143,19 +1143,19 @@ class GridfinityRuggedBox(GridfinityObject):
 
         if self.lid_window:
             r = self.render_lid_window()
-            r = r.translate((0, 0, self.box_height + GR_LID_WINDOW_H))
+            r = r.translate((0, 0, self.box_height + self.c.GR_LID_WINDOW_H))
             a.add(r, color=self.window_color, name="Lid Window")
 
         if self.front_handle and self.long_enough_for_handle:
             r = self.render_handle()
-            zo = self.right_handle_centre[2] - (GR_HANDLE_SZ - M3_CB_DEPTH)
-            r = r.translate((0, -self.box_width / 2 - GR_HANDLE_H / 2, zo))
+            zo = self.right_handle_centre[2] - (self.c.GR_HANDLE_SZ - self.c.M3_CB_DEPTH)
+            r = r.translate((0, -self.box_width / 2 - self.c.GR_HANDLE_H / 2, zo))
             a.add(r, color=self.handle_color, name="Handle")
 
         rf = rotate_x(self.render_latch(), -90)
         idx = 1
-        yo = GR_LATCH_H / 2
-        zo = self.box_height - GR_RIB_CTR + yo / 2
+        yo = self.c.GR_LATCH_H / 2
+        zo = self.box_height - self.c.GR_RIB_CTR + yo / 2
         for pt in self.front_clasp_centres:
             name = "Latch %d" % (idx)
             pt = (pt[0], pt[1] - yo, zo)

--- a/cqgridfinity/scripts/gridfinitybox.py
+++ b/cqgridfinity/scripts/gridfinitybox.py
@@ -192,7 +192,7 @@ def main():
     if argsd["solid"]:
         print(
             "  solid height ratio: %.2f  top height: %.2f mm / %.2f mm"
-            % (solid_ratio, box.top_ref_height, box.max_height + GR_BOT_H)
+            % (solid_ratio, box.top_ref_height, box.max_height + self.c.GR_BOT_H)
         )
     s = []
     if argsd["unsupported"]:

--- a/cqgridfinity/scripts/ruggedbox.py
+++ b/cqgridfinity/scripts/ruggedbox.py
@@ -354,8 +354,8 @@ def main():
     print(
         "  Exterior dim: %.1f mm x %.1f mm x %.1f mm"
         % (
-            box.box_length + 2 * (GR_RBOX_CWALL - GR_RBOX_WALL),
-            box.box_width + 2 * (GR_RBOX_CWALL - GR_RBOX_WALL),
+            box.box_length + 2 * (self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL),
+            box.box_width + 2 * (self.c.GR_RBOX_CWALL - self.c.GR_RBOX_WALL),
             box.box_height + box.lid_height,
         )
     )


### PR DESCRIPTION
In order to allow objects with altered dimensions (eg, a unit other than 42 mm, or altered tolerance), this commit moves constants into a GridfinityConfig class.  These can be altered through either passing an instance to the GridfinityObject constructor, or using the class as a context manager, for example:

```python

# Creates a box and baseplate with a 20mm width unit and 5mm height unit.
with GridfinityConfig(GRU=20, GRHU=5):
    box = GridfinityBox(2, 1, 3)
    baseplate = GridfinityBaseplate(4, 3)

# This uses normal sizes
baseplate_normal = GridfinityBaseplate(4, 3)
```

I need to add tests and documentation.